### PR TITLE
Added new rating functionality

### DIFF
--- a/exploring-national-parks/src/ParkInfo/Components/ParkInfoComponent.jsx
+++ b/exploring-national-parks/src/ParkInfo/Components/ParkInfoComponent.jsx
@@ -11,6 +11,7 @@ import React, { useState, useEffect } from 'react';
 import { ParkInfo } from '../Functionality/ParkInfo'; // Importing the functionality
 import '../../Style/parkInfo.css';
 import ParkVideos from './ParkVideos';
+import ParkRating from './ParkRating';
 
 function ParkInfoComponent() {
     const [parkJSON, setParks] = useState([]);
@@ -98,6 +99,7 @@ function ParkInfoComponent() {
                                         {park.addresses[0].city}, 
                                         {park.addresses[0].stateCode}<br></br>
                                     </address>
+                                    <ParkRating initialRating={0} onChange={(value) => console.log(value)} />
                                     <br></br>
                                 </center>
                             </div>

--- a/exploring-national-parks/src/ParkInfo/Components/ParkRating.jsx
+++ b/exploring-national-parks/src/ParkInfo/Components/ParkRating.jsx
@@ -1,0 +1,34 @@
+/**
+ * ParkRating is component for the ParkInfo component.
+ * It allows users to rate a park from 1 to 5 stars.
+ * @module ParkRating
+ * @memberof ParkInfo
+ * @returns {JSX.Element} The rendered ParkRating component.
+ */
+// ParkRating.jsx
+import React, { useState, useEffect } from 'react';
+
+const ParkRating = ({ initialRating, onChange }) => {
+    const [rating, setRating] = useState(initialRating);
+
+    const handleClick = (value) => {
+        setRating(value);
+        onChange(value);
+    };
+
+    return (
+        <div>
+            {[1, 2, 3, 4, 5].map((value) => (
+                <span
+                    key={value}
+                    style={{ cursor: 'pointer', color: value <= rating ? 'gold' : 'gray' }}
+                    onClick={() => handleClick(value)}
+                >
+          ★
+        </span>
+            ))}
+        </div>
+    );
+};
+
+export default ParkRating;


### PR DESCRIPTION
Users can rate from 0-5 starts (default zero) on each individual park page. Ratings not currently saved due to lack of backend server.